### PR TITLE
[Snackbar] fix case of UIKit.h in MDCSnackbarManager.h

### DIFF
--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-#import <UIKit/UIKIt.h>
+#import <UIKit/UIKit.h>
 
 @class MDCSnackbarMessage;
 @protocol MDCSnackbarSuspensionToken;


### PR DESCRIPTION
In SDK, it is UIKit.framework/Versions/C/Headers/UIKit.h
Let me make the code use the same case so that it would be compiled on case sensitive filesystem.

### Thanks for starting a pull request on Material Components!

#### Don't forget:
- [ ] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [ ] Link to GitHub issues it solves. ```closes #1234```
- [ ] Sign the CLA bot. You can do this once the pull request is submitted.

[Contributing](./contributing/README.md#pull-requests) has more information and tips for a great
pull request.
